### PR TITLE
updated config_archive.xml

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -13,8 +13,7 @@
     </rpointer>
     <test_file_names>
       <tfile disposition="copy">rpointer.rof.1976-01-01-00000</tfile>
-      <!-- TODO: the following currently fails with cime6.1.73_noresm_v0 -->
-      <!-- <tfile disposition="ignore">rpointer.rof.1976-01-02-00000</tfile> -->
+      <tfile disposition="ignore">rpointer.rof.1976-01-02-00000</tfile>
       <tfile disposition="copy">rpointer.rof_9999.1976-01-01-00000</tfile>
       <tfile disposition="copy">casename.mosart.r.1976-01-01-00000.nc</tfile>
       <tfile disposition="copy">casename.mosart.rh4a.1976-01-01-00000.nc</tfile>


### PR DESCRIPTION
This removes a change made to config_archive.xml to have tests pass with cime6.1.73_noresm_v0.